### PR TITLE
test: fix the tests on macos

### DIFF
--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -2,23 +2,44 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 )
 
-func ExecNoOutput(argv ...string) error {
-	_, err := ExecOutput(argv...)
-	return err
-}
+// execCommand is the base function that handles command execution
+func execCommand(env []string, argv ...string) ([]byte, error) {
+	if len(argv) == 0 {
+		return nil, fmt.Errorf("no command provided")
+	}
 
-func ExecOutput(argv ...string) ([]byte, error) {
-	cmd := argv[0]
-	args := argv[1:]
-	c := exec.Command(cmd, args...)
+	cmd := exec.Command(argv[0], argv[1:]...)
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
 
-	// TODO: use Output?
-	out, err := c.CombinedOutput()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return out, fmt.Errorf("failed to execute command: %w\noutput:\n%s", err, string(out))
 	}
 	return out, nil
+}
+
+func ExecNoOutput(argv ...string) error {
+	_, err := execCommand(nil, argv...)
+	return err
+}
+
+func ExecOutput(argv ...string) ([]byte, error) {
+	return execCommand(nil, argv...)
+}
+
+// ExecOutputEnv executes a command with additional environment variables and returns its output
+func ExecOutputEnv(env []string, argv ...string) ([]byte, error) {
+	return execCommand(env, argv...)
+}
+
+// ExecNoOutputEnv executes a command with additional environment variables
+func ExecNoOutputEnv(env []string, argv ...string) error {
+	_, err := execCommand(env, argv...)
+	return err
 }

--- a/test/integration/container/containers.conf
+++ b/test/integration/container/containers.conf
@@ -1,5 +1,5 @@
 [containers]
-#netns="host"
+netns="host"
 userns="host"
 ipcns="host"
 utsns="host"


### PR DESCRIPTION
For this we need to properly cross-compile the orches executable for linux. Also, for some reason, netns=bridge doesn't work in podman desktop on linux, so we need to use netns=host, and thus cannot use PublishPort. Let's use --listen instead. It's a big ugly, but it works.